### PR TITLE
Create harbour-unitconverter-sv.ts

### DIFF
--- a/translations/harbour-unitconverter-sv.ts
+++ b/translations/harbour-unitconverter-sv.ts
@@ -1,0 +1,363 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>AboutPage</name>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="30"/>
+        <source>Unit Converter</source>
+        <translation>Enhetskonverterare</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="36"/>
+        <source>Sailfish OS</source>
+        <translation>Sailfish OS</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="54"/>
+        <source>Version %1</source>
+        <translation>Version %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="55"/>
+        <source>Created by Mikko Leppänen</source>
+        <translation>Skapad av Mikko Leppänen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="56"/>
+        <source>Adapted by Arno Dekker</source>
+        <translation>Anpassad av Arno Dekker</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="57"/>
+        <source>The source code is available at %1</source>
+        <translation>Källkoden finns tillgänglig på %1</translation>
+    </message>
+</context>
+<context>
+    <name>FavouriteDialog</name>
+    <message>
+        <location filename="../qml/pages/FavouriteDialog.qml" line="344"/>
+        <source>Give a value...</source>
+        <translation>Ange ett värde...</translation>
+    </message>
+</context>
+<context>
+    <name>FavouritesPage</name>
+    <message>
+        <location filename="../qml/pages/FavouritesPage.qml" line="22"/>
+        <source>Deleting all favourites...</source>
+        <translation>Tar bort alla favoriter...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FavouritesPage.qml" line="49"/>
+        <source>Favourites</source>
+        <translation>Favoriter</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FavouritesPage.qml" line="54"/>
+        <source>No favourites available</source>
+        <translation>Inga favoriter tillgängliga</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FavouritesPage.qml" line="60"/>
+        <source>Delete all</source>
+        <translation>Ta bort alla</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FavouritesPage.qml" line="66"/>
+        <source>Add favourite</source>
+        <translation>Lägg till favorit</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FavouritesPage.qml" line="202"/>
+        <source>Deleting favourite...</source>
+        <translation>Tar bort favorit...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="25"/>
+        <source>Unit Converter</source>
+        <translation>Enhetskonverterare</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="36"/>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="40"/>
+        <source>Options</source>
+        <translation>Alternativ</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="46"/>
+        <source>Quick Search</source>
+        <translation>Snabbsök</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="60"/>
+        <source>Favourites</source>
+        <translation>Favoriter</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="67"/>
+        <source>Ruler</source>
+        <translation>Linjal</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsPage</name>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="40"/>
+        <source>Ruler</source>
+        <translation>Linjal</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="51"/>
+        <source>You can activate/deactivate ruler&apos;s horizontal/vertical scale. If you deactivate one of the scales, you need to touch(or multi-touch) on the screen in order to bring the measurement lines visible. By default the ruler page&apos;s back navigation is off. It can be activated by pressing on the top-left corner of the screen.</source>
+        <translation>Du kan aktivera/avaktivera linjalens horisontella/vertikala skala. Om du avaktiverar en av skalorna, måste du röra vid skärmen för att synliggöra måttlinjerna. Som standard är linjalens bakåtnavigering avstängd. Den kan aktiveras med ett tryck i övre vänstra skärmhörnet.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="60"/>
+        <source>Activate ruler&apos;s horizontal lines</source>
+        <translation>Aktivera horisontella måttlinjer</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="61"/>
+        <source>Activates ruler&apos;s horizontal lines</source>
+        <translation>Aktiverar horisontella måttlinjer</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="73"/>
+        <source>Activate ruler&apos;s vertical lines</source>
+        <translation>Aktivera vertikala måttlinjer</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="74"/>
+        <source>Activates ruler&apos;s vertical lines</source>
+        <translation>Aktiverar vertikala måttlinjer</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="85"/>
+        <source>Currency</source>
+        <translation>Valuta</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="95"/>
+        <source>You can change the rate at which the currency rates are updated. If you disable the automatic update, you have to start the update process manually.</source>
+        <translation>Du kan ändra hur ofta växelkurserna skall uppdateras. Om du inaktiverar automatisk uppdatering, måste du starta uppdateringsprocessen manuellt.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="102"/>
+        <source>Select update interval</source>
+        <translation>Välj uppdateringsintervall</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="106"/>
+        <source>Daily update</source>
+        <translation>Daglig uppdatering</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="107"/>
+        <source>Weekly update</source>
+        <translation>Veckovis uppdatering</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="108"/>
+        <source>Monthly update</source>
+        <translation>Månatlig uppdatering</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="109"/>
+        <source>Always at application start</source>
+        <translation>Alltid när appen startas</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="110"/>
+        <source>Disable automatic update</source>
+        <translation>Inaktivera automatisk uppdatering</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="115"/>
+        <source>Update currency cache</source>
+        <translation>Uppdatera växelkurser</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="120"/>
+        <source>Notation</source>
+        <translation>Notation</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="125"/>
+        <source>Select number notation</source>
+        <translation>Välj siffernotation</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="126"/>
+        <source>Preferred number notation</source>
+        <translation>Föredragen siffernotation</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="130"/>
+        <source>standard</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/OptionsPage.qml" line="134"/>
+        <source>scientific</source>
+        <translation>Vetenskaplig</translation>
+    </message>
+</context>
+<context>
+    <name>QuickSearchPage</name>
+    <message>
+        <location filename="../qml/pages/QuickSearchPage.qml" line="57"/>
+        <source>Search</source>
+        <translation>Sök</translation>
+    </message>
+</context>
+<context>
+    <name>UnitConvertPage</name>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="208"/>
+        <source>Acceleration</source>
+        <translation>Acceleration</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="219"/>
+        <source>Angle</source>
+        <translation>Vinkel</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="229"/>
+        <source>Area</source>
+        <translation>Area</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="240"/>
+        <source>Currency</source>
+        <translation>Valuta</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="252"/>
+        <source>Data Storage</source>
+        <translation>Datalagring</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="263"/>
+        <source>Density</source>
+        <translation>Densitet</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="274"/>
+        <source>Energy and Work</source>
+        <translation>Energi och arbete</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="285"/>
+        <source>Flow</source>
+        <translation>Flöde</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="296"/>
+        <source>Force</source>
+        <translation>Kraft</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="307"/>
+        <source>Frequency</source>
+        <translation>Frekvens</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="318"/>
+        <source>Fuel Consumption</source>
+        <translation>Bränslekonsumtion</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="329"/>
+        <source>Length</source>
+        <translation>Längd</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="340"/>
+        <source>Magnetic Field Strength</source>
+        <translation>Magnetisk fältstyrka</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="351"/>
+        <source>Magnetic Flux Density</source>
+        <translation>Magnetisk flödestäthet</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="362"/>
+        <source>Mass</source>
+        <translation>Massa</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="373"/>
+        <source>Numbers</source>
+        <translation>Siffertal</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="386"/>
+        <source>Power</source>
+        <translation>Effekt</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="397"/>
+        <source>Pressure</source>
+        <translation>Tryck</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="408"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="419"/>
+        <source>Temperature</source>
+        <translation>Temperatur</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="430"/>
+        <source>Time</source>
+        <translation>Tid</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="441"/>
+        <source>Torque</source>
+        <translation>Vridmoment</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/UnitConvertPage.qml" line="452"/>
+        <source>Volume</source>
+        <translation>Volym</translation>
+    </message>
+</context>
+<context>
+    <name>UnitWindow</name>
+    <message>
+        <location filename="../qml/pages/components/UnitWindow.qml" line="39"/>
+        <source>From</source>
+        <translation>Från</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/components/UnitWindow.qml" line="57"/>
+        <source>To</source>
+        <translation>Till</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/components/UnitWindow.qml" line="78"/>
+        <source>Give a new rate</source>
+        <translation>Ange ett nytt värde</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/components/UnitWindow.qml" line="79"/>
+        <source>Currency rate</source>
+        <translation>Växelkurs</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Swedish translation if wanted.
There's one minor problem in Swedish translation for Unit Converter, "Enhetskonverterare" is slightly to long on about page. Should I skip translation, or do you want to change font size? Font size is  changed to 1.3 in my second screen shot.
AboutPage Line 33: `font.pixelSize: Theme.fontSizeExtraLarge * 1.3`

![skarmbild_20180418_001](https://user-images.githubusercontent.com/2996154/38937915-a725fa46-4324-11e8-9ac1-24f0ad25746a.png)
![skarmbild_20180418_003](https://user-images.githubusercontent.com/2996154/38937932-acd19ac2-4324-11e8-87d8-75a72e98621e.png)
